### PR TITLE
feat: add job management with CRUD operations, enums, and policies

### DIFF
--- a/back-wis/app/Enums/ExperienceLevel.php
+++ b/back-wis/app/Enums/ExperienceLevel.php
@@ -1,0 +1,12 @@
+<?php
+
+namespace App\Enums;
+
+enum ExperienceLevel: string
+{
+    case DEBUTANT = 'debutant';
+    case JUNIOR = 'junior';
+    case CONFIRME = 'confirme';
+    case SENIOR = 'senior';
+    case EXPERT = 'expert';
+}

--- a/back-wis/app/Enums/JobType.php
+++ b/back-wis/app/Enums/JobType.php
@@ -1,0 +1,14 @@
+<?php
+
+namespace App\Enums;
+
+enum JobType: string
+{
+    case CDI = 'cdi';
+    case CDD = 'cdd';
+    case FREELANCE = 'freelance';
+    case STAGE = 'stage';
+    case ALTERNANCE = 'alternance';
+    case Apprentissage = 'apprentissage';
+    case VOCATATION = 'vocation';
+}

--- a/back-wis/app/Http/Controllers/JobController.php
+++ b/back-wis/app/Http/Controllers/JobController.php
@@ -1,0 +1,54 @@
+<?php
+
+namespace App\Http\Controllers;
+
+use App\Http\Requests\JobRequest;
+use App\Http\Resources\JobResource;
+use App\Models\Job;
+
+class JobController extends Controller
+{
+    public function index()
+    {
+        $this->authorize('viewAny', Job::class);
+
+        return JobResource::collection(Job::with(['compagny', 'recruiter'])->get());
+    }
+
+    public function store(JobRequest $request)
+    {
+        $this->authorize('create', Job::class);
+        $data = $request->validated();
+
+        // Si user_id n'est pas fourni, utiliser l'utilisateur authentifié
+        $data['creatorId'] = auth()->id();
+        $data['compagny_id'] = auth()->user()->compagny->id;
+
+        return new JobResource(Job::create($data)::with(['compagny', 'recruiter']));
+    }
+
+    public function show(Job $job)
+    {
+        $this->authorize('view', $job);
+
+        return new JobResource($job);
+    }
+
+    public function update(JobRequest $request, Job $job)
+    {
+        $this->authorize('update', $job);
+
+        $job->update($request->validated());
+
+        return new JobResource($job);
+    }
+
+    public function destroy(Job $job)
+    {
+        $this->authorize('delete', $job);
+
+        $job->delete();
+
+        return response()->json();
+    }
+}

--- a/back-wis/app/Http/Requests/JobRequest.php
+++ b/back-wis/app/Http/Requests/JobRequest.php
@@ -1,0 +1,29 @@
+<?php
+
+namespace App\Http\Requests;
+
+use App\Enums\ExperienceLevel;
+use App\Enums\JobType;
+use Illuminate\Foundation\Http\FormRequest;
+use Illuminate\Validation\Rule;
+
+class JobRequest extends FormRequest
+{
+    public function rules(): array
+    {
+        return [
+            'title' => ['required'],
+            'description' => ['required'],
+            'requirements' => ['nullable', 'array'],
+            'salary' => ['nullable', 'numeric'],
+            'experienceLevel' => ['required', Rule::enum(ExperienceLevel::class)],
+            'location' => ['nullable'],
+            'jobtype' => ['required', Rule::enum(JobType::class)],
+        ];
+    }
+
+    public function authorize(): bool
+    {
+        return true;
+    }
+}

--- a/back-wis/app/Http/Resources/JobResource.php
+++ b/back-wis/app/Http/Resources/JobResource.php
@@ -1,0 +1,29 @@
+<?php
+
+namespace App\Http\Resources;
+
+use App\Models\Job;
+use Illuminate\Http\Request;
+use Illuminate\Http\Resources\Json\JsonResource;
+
+/** @mixin Job */
+class JobResource extends JsonResource
+{
+    public function toArray(Request $request): array
+    {
+        return [
+            'id' => $this->id,
+            'title' => $this->title,
+            'description' => $this->description,
+            'requirements' => $this->requirements,
+            'salary' => $this->salary,
+            'experienceLevel' => $this->experienceLevel,
+            'location' => $this->location,
+            'jobtype' => $this->jobtype,
+            'creator' => $this->recruiter,
+            'compagny' => $this->compagny,
+            'created_at' => $this->created_at,
+            'updated_at' => $this->updated_at,
+        ];
+    }
+}

--- a/back-wis/app/Models/Job.php
+++ b/back-wis/app/Models/Job.php
@@ -1,0 +1,42 @@
+<?php
+
+namespace App\Models;
+
+use App\Enums\ExperienceLevel;
+use App\Enums\JobType;
+use Illuminate\Database\Eloquent\Model;
+use Illuminate\Database\Eloquent\Relations\BelongsTo;
+
+class Job extends Model
+{
+    protected $fillable = [
+        'title',
+        'description',
+        'requirements',
+        'salary',
+        'experienceLevel',
+        'location',
+        'jobtype',
+        'creatorId',
+        'compagny_id',
+    ];
+
+    public function recruiter(): BelongsTo
+    {
+        return $this->belongsTo(User::class, 'creatorId');
+    }
+
+    public function compagny(): BelongsTo
+    {
+        return $this->belongsTo(Compagny::class);
+    }
+
+    protected function casts(): array
+    {
+        return [
+            'requirements' => 'array',
+            'experienceLevel' => ExperienceLevel::class,
+            'jobtype' => JobType::class,
+        ];
+    }
+}

--- a/back-wis/app/Policies/JobPolicy.php
+++ b/back-wis/app/Policies/JobPolicy.php
@@ -1,0 +1,51 @@
+<?php
+
+namespace App\Policies;
+
+use App\Enums\UserRole;
+use App\Models\Job;
+use App\Models\User;
+use Illuminate\Auth\Access\HandlesAuthorization;
+
+class JobPolicy
+{
+    use HandlesAuthorization;
+
+    public function viewAny(?User $user): bool
+    {
+        return true;
+    }
+
+    public function view(?User $user, Job $job): bool
+    {
+        return true;
+    }
+
+    public function create(User $user): bool
+    {
+        return $user->hasRole(UserRole::ADMIN) ||
+            ($user->hasRole(UserRole::RECRUITER) && $user->compagny);
+    }
+
+    public function update(User $user, Job $job): bool
+    {
+        return $user->hasRole(UserRole::ADMIN) ||
+            ($user->hasRole(UserRole::RECRUITER) and $user->id === $job->creatorId && $user->compagny);
+    }
+
+    public function delete(User $user, Job $job): bool
+    {
+        return $user->hasRole(UserRole::ADMIN) ||
+            ($user->hasRole(UserRole::RECRUITER) and $user->id === $job->creatorId && $user->compagny);
+    }
+
+    public function restore(User $user, Job $job): bool
+    {
+        return $user->hasRole(UserRole::ADMIN);
+    }
+
+    public function forceDelete(User $user, Job $job): bool
+    {
+        return $user->hasRole(UserRole::ADMIN);
+    }
+}

--- a/back-wis/app/Providers/AuthServiceProvider.php
+++ b/back-wis/app/Providers/AuthServiceProvider.php
@@ -2,6 +2,8 @@
 
 namespace App\Providers;
 
+use App\Models\Job;
+use App\Policies\JobPolicy;
 use Illuminate\Auth\Notifications\ResetPassword;
 use Illuminate\Foundation\Support\Providers\AuthServiceProvider as ServiceProvider;
 
@@ -14,6 +16,7 @@ class AuthServiceProvider extends ServiceProvider
      */
     protected $policies = [
         // 'App\Models\Model' => 'App\Policies\ModelPolicy',
+        Job::class => JobPolicy::class,
     ];
 
     /**
@@ -24,7 +27,7 @@ class AuthServiceProvider extends ServiceProvider
         $this->registerPolicies();
 
         ResetPassword::createUrlUsing(function (object $notifiable, string $token) {
-            return config('app.frontend_url')."/password-reset/$token?email={$notifiable->getEmailForPasswordReset()}";
+            return config('app.frontend_url') . "/password-reset/$token?email={$notifiable->getEmailForPasswordReset()}";
         });
 
         //

--- a/back-wis/config/queue.php
+++ b/back-wis/config/queue.php
@@ -36,7 +36,7 @@ return [
 
         'database' => [
             'driver' => 'database',
-            'table' => 'jobs',
+            'table' => 'queue_jobs',
             'queue' => 'default',
             'retry_after' => 90,
             'after_commit' => false,

--- a/back-wis/database/migrations/2025_09_21_223149_create_jobs_table.php
+++ b/back-wis/database/migrations/2025_09_21_223149_create_jobs_table.php
@@ -1,0 +1,31 @@
+<?php
+
+use App\Models\Compagny;
+use App\Models\User;
+use Illuminate\Database\Migrations\Migration;
+use Illuminate\Database\Schema\Blueprint;
+use Illuminate\Support\Facades\Schema;
+
+return new class extends Migration {
+    public function up(): void
+    {
+        Schema::create('jobs', function (Blueprint $table) {
+            $table->id();
+            $table->string('title');
+            $table->string('description');
+            $table->json('requirements')->nullable();
+            $table->decimal('salary')->nullable();
+            $table->string('experienceLevel');
+            $table->string('location')->nullable();
+            $table->string('jobtype');
+            $table->foreignIdFor(User::class, 'creatorId')->constrained('users');
+            $table->foreignIdFor(Compagny::class)->constrained('compagnies')->onDelete('cascade');
+            $table->timestamps();
+        });
+    }
+
+    public function down(): void
+    {
+        Schema::dropIfExists('jobs');
+    }
+};

--- a/back-wis/database/migrations/2025_09_22_120724_create_queue_jobs_table.php
+++ b/back-wis/database/migrations/2025_09_22_120724_create_queue_jobs_table.php
@@ -1,0 +1,32 @@
+<?php
+
+use Illuminate\Database\Migrations\Migration;
+use Illuminate\Database\Schema\Blueprint;
+use Illuminate\Support\Facades\Schema;
+
+return new class extends Migration
+{
+    /**
+     * Run the migrations.
+     */
+    public function up(): void
+    {
+        Schema::create('queue_jobs', function (Blueprint $table) {
+            $table->bigIncrements('id');
+            $table->string('queue')->index();
+            $table->longText('payload');
+            $table->unsignedTinyInteger('attempts');
+            $table->unsignedInteger('reserved_at')->nullable();
+            $table->unsignedInteger('available_at');
+            $table->unsignedInteger('created_at');
+        });
+    }
+
+    /**
+     * Reverse the migrations.
+     */
+    public function down(): void
+    {
+        Schema::dropIfExists('queue_jobs');
+    }
+};

--- a/back-wis/routes/api.php
+++ b/back-wis/routes/api.php
@@ -17,3 +17,4 @@ use Illuminate\Support\Facades\Route;
 require __DIR__.'/auth.php';
 require __DIR__.'/compagny.php';
 require __DIR__.'/profile.php';
+require __DIR__.'/job.php';

--- a/back-wis/routes/job.php
+++ b/back-wis/routes/job.php
@@ -1,0 +1,11 @@
+<?php
+
+use App\Http\Controllers\JobController;
+
+Route::prefix('job')->group(function () {
+    Route::get('/', [JobController::class, 'index']);
+    Route::get('/{job}', [JobController::class, 'show']);
+    Route::post('/', [JobController::class, 'store'])->middleware('auth');
+    Route::post('/{job}', [JobController::class, 'update'])->middleware('auth');
+    Route::delete('/{job}', [JobController::class, 'destroy'])->middleware('auth');
+});


### PR DESCRIPTION
- Introduced job routes with CRUD endpoints in `routes/job.php`.
- Implemented `JobController` for handling job-related actions.
- Created `JobRequest` for request validation.
- Added `Job` model with relationships and cast definitions.
- Defined `JobPolicy` for role-based access control.
- Added enums `JobType` and `ExperienceLevel`.
- Created `JobResource` for resource formatting.
- Added database migrations for `jobs` and `queue_jobs`.
- Updated queue configuration to use `queue_jobs` table.
- Registered `JobPolicy` in `AuthServiceProvider`.