### PR TITLE
feat: add navigation badges for Filament resources

### DIFF
--- a/back-wis/app/Filament/Admin/Resources/Compagnies/CompagnyResource.php
+++ b/back-wis/app/Filament/Admin/Resources/Compagnies/CompagnyResource.php
@@ -24,6 +24,15 @@ class CompagnyResource extends Resource
 
     protected static ?string $recordTitleAttribute = 'name';
 
+    public static function getNavigationBadgeColor(): ?string
+    {
+        return static::getModel()::count() > 10 ? 'warning' : 'primary';
+    }
+    public static function getNavigationBadge(): ?string
+    {
+        return static::getModel()::count();
+    }
+
     public static function form(Schema $schema): Schema
     {
         return CompagnyForm::configure($schema);

--- a/back-wis/app/Filament/Admin/Resources/Jobs/JobResource.php
+++ b/back-wis/app/Filament/Admin/Resources/Jobs/JobResource.php
@@ -24,6 +24,15 @@ class JobResource extends Resource
 
     protected static ?string $recordTitleAttribute = 'yes';
 
+    public static function getNavigationBadgeColor(): ?string
+    {
+        return static::getModel()::count() > 10 ? 'warning' : 'primary';
+    }
+    public static function getNavigationBadge(): ?string
+    {
+        return static::getModel()::count();
+    }
+
     public static function form(Schema $schema): Schema
     {
         return JobForm::configure($schema);

--- a/back-wis/app/Filament/Admin/Resources/Users/UserResource.php
+++ b/back-wis/app/Filament/Admin/Resources/Users/UserResource.php
@@ -24,6 +24,15 @@ class UserResource extends Resource
 
     protected static ?string $recordTitleAttribute = 'email';
 
+    public static function getNavigationBadgeColor(): ?string
+    {
+        return static::getModel()::count() > 10 ? 'warning' : 'primary';
+    }
+    public static function getNavigationBadge(): ?string
+    {
+        return static::getModel()::count();
+    }
+
     public static function form(Schema $schema): Schema
     {
         return UserForm::configure($schema);


### PR DESCRIPTION
- Introduced `getNavigationBadge` and `getNavigationBadgeColor` methods for `UserResource`, `CompagnyResource`, and `JobResource`.
- Display badges indicating count and color-coded status based on thresholds.