### PR TITLE
feat: add recruiter management to Filament resources

### DIFF
--- a/back-wis/app/Filament/Admin/Resources/Compagnies/CompagnyResource.php
+++ b/back-wis/app/Filament/Admin/Resources/Compagnies/CompagnyResource.php
@@ -6,6 +6,7 @@ use App\Filament\Admin\Resources\Compagnies\Pages\CreateCompagny;
 use App\Filament\Admin\Resources\Compagnies\Pages\EditCompagny;
 use App\Filament\Admin\Resources\Compagnies\Pages\ListCompagnies;
 use App\Filament\Admin\Resources\Compagnies\Pages\ViewCompagny;
+use App\Filament\Admin\Resources\Compagnies\RelationManagers\RecruitersRelationManager;
 use App\Filament\Admin\Resources\Compagnies\Schemas\CompagnyForm;
 use App\Filament\Admin\Resources\Compagnies\Schemas\CompagnyInfolist;
 use App\Filament\Admin\Resources\Compagnies\Tables\CompagniesTable;
@@ -51,7 +52,7 @@ class CompagnyResource extends Resource
     public static function getRelations(): array
     {
         return [
-            //
+            RecruitersRelationManager::class,
         ];
     }
 

--- a/back-wis/app/Filament/Admin/Resources/Compagnies/RelationManagers/RecruitersRelationManager.php
+++ b/back-wis/app/Filament/Admin/Resources/Compagnies/RelationManagers/RecruitersRelationManager.php
@@ -1,0 +1,47 @@
+<?php
+
+namespace App\Filament\Admin\Resources\Compagnies\RelationManagers;
+
+use App\Filament\Admin\Resources\Users\Schemas\UserForm;
+use App\Filament\Admin\Resources\Users\Tables\UsersTable;
+use Filament\Actions\ActionGroup;
+use Filament\Actions\CreateAction;
+use Filament\Actions\DeleteAction;
+use Filament\Actions\DetachAction;
+use Filament\Actions\EditAction;
+use Filament\Actions\ViewAction;
+use Filament\Resources\RelationManagers\RelationManager;
+use Filament\Schemas\Schema;
+use Filament\Tables\Table;
+
+class RecruitersRelationManager extends RelationManager
+{
+    protected static string $relationship = 'recruiters';
+
+    protected static ?string $recordTitleAttribute = 'email';
+
+    public function form(Schema $schema): Schema
+    {
+        return UserForm::configure($schema);
+    }
+
+    public function table(Table $table): Table
+    {
+        $table = UsersTable::configure($table);
+
+        return $table
+            ->headerActions([
+                CreateAction::make()
+                    ->label('Add Recruiter')
+                    ->modalHeading('Create Recruiter')
+            ])
+            ->recordActions([
+                ActionGroup::make([
+                    ViewAction::make(),
+                    EditAction::make(),
+                    DeleteAction::make(),
+                ]),
+                DetachAction::make(),
+            ]);
+    }
+}

--- a/back-wis/app/Filament/Admin/Resources/Jobs/Schemas/JobInfolist.php
+++ b/back-wis/app/Filament/Admin/Resources/Jobs/Schemas/JobInfolist.php
@@ -18,7 +18,7 @@ class JobInfolist
                 TextEntry::make('experienceLevel'),
                 TextEntry::make('location'),
                 TextEntry::make('jobtype'),
-                TextEntry::make('creatorId')
+                TextEntry::make('recruiter.email')
                     ->numeric(),
                 TextEntry::make('compagny.name')
                     ->numeric(),

--- a/back-wis/app/Filament/Admin/Resources/Jobs/Tables/JobsTable.php
+++ b/back-wis/app/Filament/Admin/Resources/Jobs/Tables/JobsTable.php
@@ -28,8 +28,9 @@ class JobsTable
                     ->searchable(),
                 TextColumn::make('jobtype')
                     ->searchable(),
-                TextColumn::make('creatorId')
-                    ->numeric()
+                TextColumn::make('recruiter.email')
+                    ->label('Recruiter')
+                    ->searchable()
                     ->sortable(),
                 TextColumn::make('compagny.name')
                     ->numeric()

--- a/back-wis/app/Filament/Admin/Resources/Users/Schemas/UserForm.php
+++ b/back-wis/app/Filament/Admin/Resources/Users/Schemas/UserForm.php
@@ -21,17 +21,17 @@ class UserForm
                     ->label('Email address')
                     ->email()
                     ->required(),
-                DateTimePicker::make('email_verified_at'),
-                TextInput::make('password')
-                    ->password()
-                    ->required(),
                 TextInput::make('phoneNumber')
                     ->tel(),
                 Select::make('role')
                     ->options(UserRole::class)
                     ->default('user'),
-                TextInput::make('compagny_id')
-                    ->numeric(),
+                Select::make('compagny_id')
+                    ->label('Compagny')
+                    ->relationship('compagny', 'name')
+                    ->preload()
+                    ->nullable()
+                    ->searchable(),
             ]);
     }
 }

--- a/back-wis/app/Filament/Admin/Resources/Users/Schemas/UserInfolist.php
+++ b/back-wis/app/Filament/Admin/Resources/Users/Schemas/UserInfolist.php
@@ -2,6 +2,7 @@
 
 namespace App\Filament\Admin\Resources\Users\Schemas;
 
+use App\Enums\UserRole;
 use Filament\Infolists\Components\TextEntry;
 use Filament\Schemas\Schema;
 
@@ -18,7 +19,14 @@ class UserInfolist
                 TextEntry::make('email_verified_at')
                     ->dateTime(),
                 TextEntry::make('phoneNumber'),
-                TextEntry::make('role'),
+                TextEntry::make('role')
+                    ->badge()
+                    ->color(fn (UserRole|string $state): string => match ($state) {
+                        UserRole::USER => 'primary',
+                        UserRole::RECRUITER => 'success',
+                        UserRole::ADMIN => 'danger',
+                        default => 'secondary',
+                    }),
                 TextEntry::make('compagny_id')
                     ->numeric(),
                 TextEntry::make('created_at')

--- a/back-wis/app/Filament/Admin/Resources/Users/Tables/UsersTable.php
+++ b/back-wis/app/Filament/Admin/Resources/Users/Tables/UsersTable.php
@@ -2,6 +2,7 @@
 
 namespace App\Filament\Admin\Resources\Users\Tables;
 
+use App\Enums\UserRole;
 use Filament\Actions\BulkActionGroup;
 use Filament\Actions\DeleteBulkAction;
 use Filament\Actions\EditAction;
@@ -24,14 +25,22 @@ class UsersTable
                     ->searchable(),
                 TextColumn::make('email_verified_at')
                     ->dateTime()
-                    ->sortable(),
+                    ->sortable()
+                    ->toggleable(isToggledHiddenByDefault: true),
                 TextColumn::make('phoneNumber')
                     ->searchable(),
                 TextColumn::make('role')
+                    ->badge()
+                    ->color(fn (UserRole|string $state): string => match ($state) {
+                        UserRole::USER => 'primary',
+                        UserRole::RECRUITER => 'success',
+                        UserRole::ADMIN => 'danger',
+                        default => 'secondary',
+                    })
                     ->searchable(),
-                TextColumn::make('compagny_id')
-                    ->numeric()
-                    ->sortable(),
+                TextColumn::make('compagny.name')
+                    ->label('Compagny')
+                    ->searchable(),
                 TextColumn::make('created_at')
                     ->dateTime()
                     ->sortable()

--- a/back-wis/app/Models/Compagny.php
+++ b/back-wis/app/Models/Compagny.php
@@ -2,6 +2,7 @@
 
 namespace App\Models;
 
+use App\Enums\UserRole;
 use Illuminate\Database\Eloquent\Model;
 
 class Compagny extends Model
@@ -15,6 +16,6 @@ class Compagny extends Model
     ];
     public function recruiters()
     {
-        return $this->hasMany(User::class)->where('role', 'RECRUITER');
+        return $this->hasMany(User::class)->where('role', UserRole::RECRUITER);
     }
 }

--- a/back-wis/app/Providers/Filament/AdminPanelProvider.php
+++ b/back-wis/app/Providers/Filament/AdminPanelProvider.php
@@ -52,6 +52,7 @@ class AdminPanelProvider extends PanelProvider
                 DisableBladeIconComponents::class,
                 DispatchServingFilamentEvent::class,
             ])
+            ->readOnlyRelationManagersOnResourceViewPagesByDefault(false)
             ->authMiddleware([
                 Authenticate::class,
             ]);

--- a/back-wis/database/seeders/DatabaseSeeder.php
+++ b/back-wis/database/seeders/DatabaseSeeder.php
@@ -12,11 +12,13 @@ class DatabaseSeeder extends Seeder
      */
     public function run(): void
     {
-        // \App\Models\User::factory(10)->create();
-
-        // \App\Models\User::factory()->create([
-        //     'name' => 'Test User',
-        //     'email' => 'test@example.com',
-        // ]);
+         \App\Models\User::factory()->create([
+             'firstname' => 'admin',
+             'name' => 'admin',
+             'email' => 'admin@gmail.com',
+             'role' => \App\Enums\UserRole::ADMIN,
+             'password' => 'passer',
+             'phoneNumber' => '7700000000',
+         ]);
     }
 }


### PR DESCRIPTION
- Introduced `RecruitersRelationManager` to manage recruiters within `CompagnyResource`.
- Updated `UsersTable` with badges and searchable `compagny.name`.
- Enhanced `UserForm` with role-based selection and improved `compagny` dropdown.
- Streamlined recruiter display in `JobsTable` and `JobInfolist`.
- Adjusted `Compagny` model to utilize `UserRole::RECRUITER` for relationship filtering.
- Seeded admin user in `DatabaseSeeder` and updated `AdminPanelProvider` configuration.