### PR TITLE
feat: add company verification management with Filament integration

### DIFF
--- a/back-wis/app/Enums/VerificationStatus.php
+++ b/back-wis/app/Enums/VerificationStatus.php
@@ -1,0 +1,10 @@
+<?php
+
+namespace App\Enums;
+
+enum VerificationStatus: string
+{
+    case PENDING = 'pending';
+    case REJECTED = 'rejected';
+    case APPROVED = 'approved';
+}

--- a/back-wis/app/Filament/Admin/Resources/Compagnies/CompagnyResource.php
+++ b/back-wis/app/Filament/Admin/Resources/Compagnies/CompagnyResource.php
@@ -16,12 +16,14 @@ use Filament\Resources\Resource;
 use Filament\Schemas\Schema;
 use Filament\Support\Icons\Heroicon;
 use Filament\Tables\Table;
+use UnitEnum;
 
 class CompagnyResource extends Resource
 {
     protected static ?string $model = Compagny::class;
+    protected static string | UnitEnum | null $navigationGroup = 'Compagnies';
 
-    protected static string|BackedEnum|null $navigationIcon = Heroicon::OutlinedRectangleStack;
+    protected static string|BackedEnum|null $navigationIcon = Heroicon::OutlinedBuildingOffice2;
 
     protected static ?string $recordTitleAttribute = 'name';
 

--- a/back-wis/app/Filament/Admin/Resources/CompagnyVerifications/CompagnyVerificationsResource.php
+++ b/back-wis/app/Filament/Admin/Resources/CompagnyVerifications/CompagnyVerificationsResource.php
@@ -1,0 +1,62 @@
+<?php
+
+namespace App\Filament\Admin\Resources\CompagnyVerifications;
+
+use App\Filament\Admin\Resources\CompagnyVerifications\Pages\CreateCompagnyVerifications;
+use App\Filament\Admin\Resources\CompagnyVerifications\Pages\EditCompagnyVerifications;
+use App\Filament\Admin\Resources\CompagnyVerifications\Pages\ListCompagnyVerifications;
+use App\Filament\Admin\Resources\CompagnyVerifications\Schemas\CompagnyVerificationsForm;
+use App\Filament\Admin\Resources\CompagnyVerifications\Tables\CompagnyVerificationsTable;
+use App\Models\CompagnyVerifications;
+use BackedEnum;
+use Filament\Resources\Resource;
+use Filament\Schemas\Schema;
+use Filament\Support\Icons\Heroicon;
+use Filament\Tables\Table;
+use UnitEnum;
+
+class CompagnyVerificationsResource extends Resource
+{
+    protected static ?string $model = CompagnyVerifications::class;
+
+    protected static string | UnitEnum | null $navigationGroup = 'Compagnies';
+
+    protected static string|BackedEnum|null $navigationIcon = Heroicon::OutlinedCheckBadge;
+
+    protected static ?string $recordTitleAttribute = 'ninea';
+
+    public static function getNavigationBadgeColor(): ?string
+    {
+        return static::getModel()::count() > 10 ? 'warning' : 'primary';
+    }
+    public static function getNavigationBadge(): ?string
+    {
+        return static::getModel()::count();
+    }
+
+    public static function form(Schema $schema): Schema
+    {
+        return CompagnyVerificationsForm::configure($schema);
+    }
+
+    public static function table(Table $table): Table
+    {
+        return CompagnyVerificationsTable::configure($table);
+    }
+
+    public static function getRelations(): array
+    {
+        return [
+            //
+        ];
+    }
+
+    public static function getPages(): array
+    {
+        return [
+            'index' => ListCompagnyVerifications::route('/'),
+            'create' => CreateCompagnyVerifications::route('/create'),
+            'edit' => EditCompagnyVerifications::route('/{record}/edit'),
+        ];
+    }
+}

--- a/back-wis/app/Filament/Admin/Resources/CompagnyVerifications/Pages/CreateCompagnyVerifications.php
+++ b/back-wis/app/Filament/Admin/Resources/CompagnyVerifications/Pages/CreateCompagnyVerifications.php
@@ -1,0 +1,11 @@
+<?php
+
+namespace App\Filament\Admin\Resources\CompagnyVerifications\Pages;
+
+use App\Filament\Admin\Resources\CompagnyVerifications\CompagnyVerificationsResource;
+use Filament\Resources\Pages\CreateRecord;
+
+class CreateCompagnyVerifications extends CreateRecord
+{
+    protected static string $resource = CompagnyVerificationsResource::class;
+}

--- a/back-wis/app/Filament/Admin/Resources/CompagnyVerifications/Pages/EditCompagnyVerifications.php
+++ b/back-wis/app/Filament/Admin/Resources/CompagnyVerifications/Pages/EditCompagnyVerifications.php
@@ -1,0 +1,19 @@
+<?php
+
+namespace App\Filament\Admin\Resources\CompagnyVerifications\Pages;
+
+use App\Filament\Admin\Resources\CompagnyVerifications\CompagnyVerificationsResource;
+use Filament\Actions\DeleteAction;
+use Filament\Resources\Pages\EditRecord;
+
+class EditCompagnyVerifications extends EditRecord
+{
+    protected static string $resource = CompagnyVerificationsResource::class;
+
+    protected function getHeaderActions(): array
+    {
+        return [
+            DeleteAction::make(),
+        ];
+    }
+}

--- a/back-wis/app/Filament/Admin/Resources/CompagnyVerifications/Pages/ListCompagnyVerifications.php
+++ b/back-wis/app/Filament/Admin/Resources/CompagnyVerifications/Pages/ListCompagnyVerifications.php
@@ -1,0 +1,19 @@
+<?php
+
+namespace App\Filament\Admin\Resources\CompagnyVerifications\Pages;
+
+use App\Filament\Admin\Resources\CompagnyVerifications\CompagnyVerificationsResource;
+use Filament\Actions\CreateAction;
+use Filament\Resources\Pages\ListRecords;
+
+class ListCompagnyVerifications extends ListRecords
+{
+    protected static string $resource = CompagnyVerificationsResource::class;
+
+    protected function getHeaderActions(): array
+    {
+        return [
+            CreateAction::make(),
+        ];
+    }
+}

--- a/back-wis/app/Filament/Admin/Resources/CompagnyVerifications/Schemas/CompagnyVerificationsForm.php
+++ b/back-wis/app/Filament/Admin/Resources/CompagnyVerifications/Schemas/CompagnyVerificationsForm.php
@@ -1,0 +1,41 @@
+<?php
+
+namespace App\Filament\Admin\Resources\CompagnyVerifications\Schemas;
+
+use App\Enums\VerificationStatus;
+use Filament\Forms\Components\Select;
+use Filament\Forms\Components\TextInput;
+use Filament\Forms\Components\Textarea;
+use Filament\Schemas\Schema;
+
+class CompagnyVerificationsForm
+{
+    public static function configure(Schema $schema): Schema
+    {
+        return $schema
+            ->components([
+                Select::make('compagny_id')
+                    ->relationship('compagny', 'name')
+                    ->disabled()
+                    ->required(),
+                Select::make('submitted_by')
+                    ->relationship('submittedBy', 'name')
+                    ->disabled()
+                    ->required(),
+                TextInput::make('ninea')
+                    ->disabled()
+                    ->required(),
+                TextInput::make('rccm')
+                    ->disabled(),
+                Textarea::make('notes')
+                    ->disabled()
+                    ->columnSpanFull(),
+                Select::make('status')
+                    ->options(VerificationStatus::class)
+                    ->default('pending')
+                    ->required(),
+                Textarea::make('admin_notes')
+                    ->columnSpanFull(),
+            ]);
+    }
+}

--- a/back-wis/app/Filament/Admin/Resources/CompagnyVerifications/Tables/CompagnyVerificationsTable.php
+++ b/back-wis/app/Filament/Admin/Resources/CompagnyVerifications/Tables/CompagnyVerificationsTable.php
@@ -1,0 +1,59 @@
+<?php
+
+namespace App\Filament\Admin\Resources\CompagnyVerifications\Tables;
+
+use App\Enums\VerificationStatus;
+use Filament\Actions\BulkActionGroup;
+use Filament\Actions\DeleteBulkAction;
+use Filament\Actions\EditAction;
+use Filament\Tables\Columns\TextColumn;
+use Filament\Tables\Table;
+
+class CompagnyVerificationsTable
+{
+    public static function configure(Table $table): Table
+    {
+        return $table
+            ->columns([
+                TextColumn::make('compagny.name')
+                    ->numeric()
+                    ->sortable(),
+                TextColumn::make('compagny.owner.email', )
+                    ->label('Submitted By')
+                    ->numeric()
+                    ->sortable(),
+                TextColumn::make('status')
+                    ->badge()
+                    ->color(fn (VerificationStatus|string $state): string => match ($state) {
+                        VerificationStatus::APPROVED => 'primary',
+                        VerificationStatus::PENDING => 'success',
+                        VerificationStatus::REJECTED => 'danger',
+                        default => 'secondary',
+                    })
+                    ->searchable(),
+                TextColumn::make('ninea')
+                    ->searchable(),
+                TextColumn::make('rccm')
+                    ->searchable(),
+                TextColumn::make('created_at')
+                    ->dateTime()
+                    ->sortable()
+                    ->toggleable(isToggledHiddenByDefault: true),
+                TextColumn::make('updated_at')
+                    ->dateTime()
+                    ->sortable()
+                    ->toggleable(isToggledHiddenByDefault: true),
+            ])
+            ->filters([
+                //
+            ])
+            ->recordActions([
+                EditAction::make(),
+            ])
+            ->toolbarActions([
+                BulkActionGroup::make([
+                    DeleteBulkAction::make(),
+                ]),
+            ]);
+    }
+}

--- a/back-wis/app/Filament/Admin/Resources/Jobs/JobResource.php
+++ b/back-wis/app/Filament/Admin/Resources/Jobs/JobResource.php
@@ -20,7 +20,7 @@ class JobResource extends Resource
 {
     protected static ?string $model = Job::class;
 
-    protected static string|BackedEnum|null $navigationIcon = Heroicon::OutlinedRectangleStack;
+    protected static string|BackedEnum|null $navigationIcon = Heroicon::OutlinedBriefcase;
 
     protected static ?string $recordTitleAttribute = 'yes';
 

--- a/back-wis/app/Filament/Admin/Resources/Users/UserResource.php
+++ b/back-wis/app/Filament/Admin/Resources/Users/UserResource.php
@@ -20,7 +20,7 @@ class UserResource extends Resource
 {
     protected static ?string $model = User::class;
 
-    protected static string|BackedEnum|null $navigationIcon = Heroicon::OutlinedRectangleStack;
+    protected static string|BackedEnum|null $navigationIcon = Heroicon::OutlinedUser;
 
     protected static ?string $recordTitleAttribute = 'email';
 

--- a/back-wis/app/Filament/Admin/Widgets/StatsOverview.php
+++ b/back-wis/app/Filament/Admin/Widgets/StatsOverview.php
@@ -2,6 +2,9 @@
 
 namespace App\Filament\Admin\Widgets;
 
+use App\Enums\VerificationStatus;
+use App\Models\Compagny;
+use App\Models\CompagnyVerifications;
 use Filament\Widgets\StatsOverviewWidget;
 use Filament\Widgets\StatsOverviewWidget\Stat;
 
@@ -21,6 +24,11 @@ class StatsOverview extends StatsOverviewWidget
                 ->descriptionIcon('heroicon-m-briefcase')
                 ->chart(\App\Models\Job::query()->latest()->take(7)->pluck('id')->toArray())
                 ->color('primary'),
+            Stat::make('Taux de compagnies vérifiées', CompagnyVerifications::where('status', VerificationStatus::APPROVED)->count() . ' / ' . Compagny::count())
+                ->description('Pourcentage de compagnies vérifiées')
+                ->descriptionIcon('heroicon-m-check-badge')
+                ->chart([CompagnyVerifications::where('status', VerificationStatus::APPROVED)->count(), CompagnyVerifications::where('status', '!==', VerificationStatus::APPROVED)->count()])
+                ->color('info'),
             Stat::make('Candidatures', \App\Models\Application::count())
                 ->description('Nombre total de candidatures')
                 ->descriptionIcon('heroicon-m-document-text')

--- a/back-wis/app/Http/Controllers/ApplicationController.php
+++ b/back-wis/app/Http/Controllers/ApplicationController.php
@@ -13,7 +13,7 @@ class ApplicationController extends Controller
     {
         $this->authorize('viewAny', Application::class);
 
-        $applications = Application::with(['job', 'candidat'])->get();
+        $applications = Application::with(['job', 'candidat'])->paginate(20);
 
         return ApplicationResource::collection($applications);
     }

--- a/back-wis/app/Http/Controllers/CompagnyVerificationsController.php
+++ b/back-wis/app/Http/Controllers/CompagnyVerificationsController.php
@@ -1,0 +1,34 @@
+<?php
+
+namespace App\Http\Controllers;
+
+use App\Http\Requests\CompanyVerificationsRequest;
+use App\Http\Resources\CompagnyVerificationsResource;
+use App\Models\CompagnyVerifications;
+
+class CompagnyVerificationsController extends Controller
+{
+    public function index()
+    {
+        $this->authorize('viewAny', CompagnyVerifications::class);
+        $verifications = CompagnyVerifications::where('submitted_by', auth()->id())->get();
+
+        return CompagnyVerificationsResource::collection($verifications);
+    }
+
+    public function store(CompanyVerificationsRequest $request)
+    {
+        $this->authorize('create', CompagnyVerifications::class);
+        $data = $request->validated();
+        $data['submitted_by'] = auth()->id();
+
+        return new CompagnyVerificationsResource(CompagnyVerifications::create($data)->load('compagny'));
+    }
+
+    public function show(CompagnyVerifications $companyVerifications)
+    {
+        $this->authorize('view', $companyVerifications);
+
+        return new CompagnyVerificationsResource($companyVerifications);
+    }
+}

--- a/back-wis/app/Http/Controllers/JobController.php
+++ b/back-wis/app/Http/Controllers/JobController.php
@@ -11,7 +11,7 @@ class JobController extends Controller
     public function index()
     {
         $this->authorize('viewAny', Job::class);
-        $jobs = Job::with(['compagny', 'recruiter'])->get();
+        $jobs = Job::with(['compagny', 'recruiter'])->paginate(20);
 
         return JobResource::collection($jobs);
     }

--- a/back-wis/app/Http/Requests/CompanyVerificationsRequest.php
+++ b/back-wis/app/Http/Requests/CompanyVerificationsRequest.php
@@ -1,0 +1,23 @@
+<?php
+
+namespace App\Http\Requests;
+
+use Illuminate\Foundation\Http\FormRequest;
+
+class CompanyVerificationsRequest extends FormRequest
+{
+    public function rules(): array
+    {
+        return [
+            'compagny_id' => ['required', 'exists:compagnies,id'],
+            'ninea' => ['required'],
+            'rccm' => ['nullable'],
+            'notes' => ['nullable', 'string', 'max:1000'],
+        ];
+    }
+
+    public function authorize(): bool
+    {
+        return true;
+    }
+}

--- a/back-wis/app/Http/Resources/CompagnyResource.php
+++ b/back-wis/app/Http/Resources/CompagnyResource.php
@@ -19,6 +19,8 @@ class CompagnyResource extends JsonResource
             'website' => $this->website,
             'location' => $this->location,
             'logo' => $this->logo ? Storage::url($this->logo) : null,
+            'owner' => $this->whenLoaded('owner'),
+            'isVerified' => $this->is_verified,
             'created_at' => $this->created_at,
             'updated_at' => $this->updated_at,
         ];

--- a/back-wis/app/Http/Resources/CompagnyVerificationsResource.php
+++ b/back-wis/app/Http/Resources/CompagnyVerificationsResource.php
@@ -1,0 +1,30 @@
+<?php
+
+namespace App\Http\Resources;
+
+use App\Models\CompanyVerifications;
+use Illuminate\Http\Request;
+use Illuminate\Http\Resources\Json\JsonResource;
+
+/** @mixin CompanyVerifications */
+class CompagnyVerificationsResource extends JsonResource
+{
+    public function toArray(Request $request): array
+    {
+        return [
+            'id' => $this->id,
+            'status' => $this->status,
+            'ninea' => $this->ninea,
+            'rccm' => $this->rccm,
+            'notes' => $this->notes,
+            'admin_notes' => $this->admin_notes,
+            'created_at' => $this->created_at,
+            'updated_at' => $this->updated_at,
+
+            'compagny_id' => $this->compagny_id,
+            'submitted_by' => $this->submitted_by,
+
+            'compagny' => new CompagnyResource($this->whenLoaded('compagny')),
+        ];
+    }
+}

--- a/back-wis/app/Http/Resources/ProfileResource.php
+++ b/back-wis/app/Http/Resources/ProfileResource.php
@@ -14,6 +14,7 @@ class ProfileResource extends JsonResource
     {
         return [
             'id' => $this->id,
+            'slug' => $this->slug,
             'resume' => $this->resume,
             'social_links' => $this->formatSocialLinks(),
             'skills' => $this->formatSkills(),

--- a/back-wis/app/Models/Compagny.php
+++ b/back-wis/app/Models/Compagny.php
@@ -3,7 +3,9 @@
 namespace App\Models;
 
 use App\Enums\UserRole;
+use App\Enums\VerificationStatus;
 use Illuminate\Database\Eloquent\Model;
+use Illuminate\Database\Eloquent\Casts\Attribute;
 
 class Compagny extends Model
 {
@@ -13,9 +15,33 @@ class Compagny extends Model
         'logo',
         'website',
         'location',
+        'owner_id',
     ];
     public function recruiters()
     {
         return $this->hasMany(User::class)->where('role', UserRole::RECRUITER);
     }
+
+    public function owner()
+    {
+        return $this->belongsTo(User::class, 'owner_id');
+    }
+
+    public function verifications()
+    {
+        return $this->hasOne(CompagnyVerifications::class);
+    }
+
+    public function isVerified(): Attribute
+    {
+        return Attribute::make(
+            get: fn () => $this->verifications?->status === VerificationStatus::APPROVED
+        );
+    }
+
+//    public function isVerified()
+//    {
+//        return $this->verifications && $this->verifications->status === \App\Enums\VerificationStatus::APPROVED;
+//    }
+
 }

--- a/back-wis/app/Models/CompagnyVerifications.php
+++ b/back-wis/app/Models/CompagnyVerifications.php
@@ -1,0 +1,34 @@
+<?php
+
+namespace App\Models;
+
+use App\Enums\VerificationStatus;
+use Illuminate\Database\Eloquent\Model;
+use Illuminate\Database\Eloquent\Relations\BelongsTo;
+
+class CompagnyVerifications extends Model
+{
+    protected $fillable = [
+        'compagny_id',
+        'submitted_by',
+        'status',
+        'ninea',
+        'rccm',
+        'notes',
+        'admin_notes',
+    ];
+
+    protected $casts = [
+        'status' => VerificationStatus::class,
+    ];
+
+    public function compagny(): BelongsTo
+    {
+        return $this->belongsTo(Compagny::class);
+    }
+
+    public function submittedBy(): BelongsTo
+    {
+        return $this->belongsTo(User::class, 'submitted_by');
+    }
+}

--- a/back-wis/app/Models/Profile.php
+++ b/back-wis/app/Models/Profile.php
@@ -8,6 +8,7 @@ use Illuminate\Database\Eloquent\Relations\BelongsTo;
 class Profile extends Model
 {
     protected $fillable = [
+        'slug',
         'resume',
         'social',
         'skills',

--- a/back-wis/app/Policies/CompagnyPolicy.php
+++ b/back-wis/app/Policies/CompagnyPolicy.php
@@ -23,12 +23,12 @@ class CompagnyPolicy
 
     public function create(User $user)
     {
-        return $user->hasRole(UserRole::ADMIN);
+        return $user->hasRole(UserRole::ADMIN) || ($user->hasRole(UserRole::RECRUITER) && !$user->compagny_id);
     }
 
     public function update(User $user, Compagny $compagny)
     {
-        return $user->hasRole(UserRole::ADMIN) || ($user->hasRole(UserRole::RECRUITER) && $user->compagny_id === $compagny->id);
+        return $user->hasRole(UserRole::ADMIN) || $compagny->owner_id === $user->id;
     }
 
     public function delete(User $user, Compagny $compagny)

--- a/back-wis/app/Policies/CompagnyVerificationsPolicy.php
+++ b/back-wis/app/Policies/CompagnyVerificationsPolicy.php
@@ -1,0 +1,28 @@
+<?php
+
+namespace App\Policies;
+
+use App\Enums\UserRole;
+use App\Models\CompagnyVerifications;
+use App\Models\User;
+use Illuminate\Auth\Access\HandlesAuthorization;
+
+class CompagnyVerificationsPolicy
+{
+    use HandlesAuthorization;
+
+    public function viewAny(User $user): bool
+    {
+        return true;
+    }
+
+    public function view(User $user, CompagnyVerifications $companyVerifications): bool
+    {
+        return $user->id == $companyVerifications->submitted_by;
+    }
+
+    public function create(User $user): bool
+    {
+        return $user->hasRole(UserRole::RECRUITER) && $user->compagny_id && !$user->compagny->is_verified;
+    }
+}

--- a/back-wis/app/Policies/JobPolicy.php
+++ b/back-wis/app/Policies/JobPolicy.php
@@ -23,20 +23,40 @@ class JobPolicy
 
     public function create(User $user): bool
     {
-        return $user->hasRole(UserRole::ADMIN) ||
-            ($user->hasRole(UserRole::RECRUITER) && $user->compagny);
+        if ($user->hasRole(UserRole::ADMIN)) {
+            return true;
+        }
+
+        // Le recruteur doit avoir une entreprise validée
+        if ($user->hasRole(UserRole::RECRUITER) && $user->compagny->is_verified) {
+            return true;
+        }
+
+        return false;
     }
 
     public function update(User $user, Job $job): bool
     {
-        return $user->hasRole(UserRole::ADMIN) ||
-            ($user->hasRole(UserRole::RECRUITER) and $user->id === $job->creatorId && $user->compagny);
+        if ($user->hasRole(UserRole::ADMIN)) {
+            return true;
+        }
+        // Le recruteur doit avoir une entreprise validée
+        if ($user->hasRole(UserRole::RECRUITER) && $user->id === $job->creatorId && $user->compagny->is_verified) {
+            return true;
+        }
+        return false;
     }
 
     public function delete(User $user, Job $job): bool
     {
-        return $user->hasRole(UserRole::ADMIN) ||
-            ($user->hasRole(UserRole::RECRUITER) and $user->id === $job->creatorId && $user->compagny);
+        if ($user->hasRole(UserRole::ADMIN)) {
+            return true;
+        }
+        // Le recruteur doit avoir une entreprise validée
+        if ($user->hasRole(UserRole::RECRUITER) && $user->id === $job->creatorId && $user->compagny->is_verified) {
+            return true;
+        }
+        return false;
     }
 
     public function restore(User $user, Job $job): bool

--- a/back-wis/app/Policies/ProfilePolicy.php
+++ b/back-wis/app/Policies/ProfilePolicy.php
@@ -18,7 +18,7 @@ class ProfilePolicy
 
     public function view(User $user, Profile $profile)
     {
-        return $user->hasRole(UserRole::ADMIN) || $user->hasRole(UserRole::RECRUITER) || $user->id === $profile->user_id;
+        return true;
     }
 
     public function create(User $user)

--- a/back-wis/app/Providers/AuthServiceProvider.php
+++ b/back-wis/app/Providers/AuthServiceProvider.php
@@ -3,8 +3,10 @@
 namespace App\Providers;
 
 use App\Models\Application;
+use App\Models\CompanyVerifications;
 use App\Models\Job;
 use App\Policies\ApplicationPolicy;
+use App\Policies\CompagnyVerificationsPolicy;
 use App\Policies\JobPolicy;
 use Illuminate\Auth\Notifications\ResetPassword;
 use Illuminate\Foundation\Support\Providers\AuthServiceProvider as ServiceProvider;
@@ -20,6 +22,7 @@ class AuthServiceProvider extends ServiceProvider
         // 'App\Models\Model' => 'App\Policies\ModelPolicy',
         Job::class => JobPolicy::class,
         Application::class => ApplicationPolicy::class,
+        CompanyVerifications::class => CompagnyVerificationsPolicy::class,
     ];
 
     /**

--- a/back-wis/database/migrations/2014_10_12_000000_create_users_table.php
+++ b/back-wis/database/migrations/2014_10_12_000000_create_users_table.php
@@ -21,7 +21,7 @@ return new class extends Migration
             $table->string('password');
             $table->string('phoneNumber')->nullable();
             $table->string('role')->default(UserRole::USER->value)->nullable();
-            $table->foreignIdFor(App\Models\Compagny::class)->nullable();
+            $table->foreignIdFor(App\Models\Compagny::class)->nullable()->constrained()->nullOnDelete();
             $table->rememberToken();
             $table->timestamps();
         });

--- a/back-wis/database/migrations/2025_08_02_132101_create_compagnies_table.php
+++ b/back-wis/database/migrations/2025_08_02_132101_create_compagnies_table.php
@@ -9,6 +9,7 @@ return new class extends Migration {
     {
         Schema::create('compagnies', function (Blueprint $table) {
             $table->id();
+            $table->foreignId('owner_id')->constrained('users')->nullOnDelete();
             $table->string('name');
             $table->string('description')->nullable();
             $table->string('website')->nullable();

--- a/back-wis/database/migrations/2025_08_02_134643_create_profiles_table.php
+++ b/back-wis/database/migrations/2025_08_02_134643_create_profiles_table.php
@@ -9,6 +9,7 @@ return new class extends Migration {
     {
         Schema::create('profiles', function (Blueprint $table) {
             $table->id();
+            $table->string('slug')->unique();
             $table->text('resume');
             $table->json('social')->nullable();
             $table->json('skills')->nullable();

--- a/back-wis/database/migrations/2025_10_04_171314_create_company_verifications_table.php
+++ b/back-wis/database/migrations/2025_10_04_171314_create_company_verifications_table.php
@@ -1,0 +1,30 @@
+<?php
+
+use App\Enums\VerificationStatus;
+use App\Models\Compagny;
+use App\Models\User;
+use Illuminate\Database\Migrations\Migration;
+use Illuminate\Database\Schema\Blueprint;
+use Illuminate\Support\Facades\Schema;
+
+return new class extends Migration {
+    public function up(): void
+    {
+        Schema::create('compagny_verifications', function (Blueprint $table) {
+            $table->id();
+            $table->foreignIdFor(Compagny::class)->constrained('compagnies');
+            $table->foreignIdFor(User::class, 'submitted_by')->constrained('users');
+            $table->string('status')->default(VerificationStatus::PENDING->value);;
+            $table->string('ninea');
+            $table->string('rccm')->nullable();
+            $table->longText('notes')->nullable();
+            $table->longText('admin_notes')->nullable();
+            $table->timestamps();
+        });
+    }
+
+    public function down(): void
+    {
+        Schema::dropIfExists('compagny_verifications');
+    }
+};

--- a/back-wis/database/seeders/DatabaseSeeder.php
+++ b/back-wis/database/seeders/DatabaseSeeder.php
@@ -18,7 +18,18 @@ class DatabaseSeeder extends Seeder
              'email' => 'admin@gmail.com',
              'role' => \App\Enums\UserRole::ADMIN,
              'password' => 'passer',
-             'phoneNumber' => '7700000000',
+             'phoneNumber' => '770000000',
          ]);
+
+        \App\Models\User::factory()->create([
+            'firstname' => 'test',
+            'name' => 'test',
+            'email' => 'test@gmail.com',
+            'role' => \App\Enums\UserRole::RECRUITER,
+            'password' => 'passer',
+            'phoneNumber' => '770000001',
+        ]);
+
+
     }
 }

--- a/back-wis/routes/api.php
+++ b/back-wis/routes/api.php
@@ -15,7 +15,8 @@ use Illuminate\Support\Facades\Route;
 */
 
 require __DIR__.'/auth.php';
-//require __DIR__.'/compagny.php';
+require __DIR__.'/compagny.php';
+require __DIR__.'/compagnyVerification.php';
 require __DIR__.'/profile.php';
 require __DIR__.'/job.php';
 require __DIR__.'/application.php';

--- a/back-wis/routes/compagnyVerification.php
+++ b/back-wis/routes/compagnyVerification.php
@@ -1,0 +1,7 @@
+<?php
+
+Route::prefix('compagny-verification')->group(function () {
+    Route::post('/', [\App\Http\Controllers\CompagnyVerificationsController::class, 'store']);
+    Route::get('/', [\App\Http\Controllers\CompagnyVerificationsController::class, 'index']);
+    Route::get('/{companyVerifications}', [\App\Http\Controllers\CompagnyVerificationsController::class, 'show']);
+})->middleware('auth');

--- a/back-wis/routes/profile.php
+++ b/back-wis/routes/profile.php
@@ -5,7 +5,7 @@ use App\Http\Controllers\ProfileController;
 
 Route::prefix('profile')->group(function () {
     Route::get('/', [ProfileController::class, 'index']);
-    Route::get('/{profile}', [ProfileController::class, 'show']);
+    Route::get('/{profile}', [ProfileController::class, 'showBySlug']);
     Route::post('/', [ProfileController::class, 'store'])->middleware('auth');
     Route::post('/{profile}', [ProfileController::class, 'update'])->middleware('auth');
     Route::delete('/{profile}', [ProfileController::class, 'destroy'])->middleware('auth');


### PR DESCRIPTION
- Introduced `CompagnyVerificationsResource` with CRUD capabilities for managing company verifications.
- Added associated pages: `ListCompagnyVerifications`, `CreateCompagnyVerifications`, and `EditCompagnyVerifications`.
- Created supporting components: `CompagnyVerificationsForm`, `CompagnyVerificationsTable`, and `CompagnyVerificationsPolicy`.
- Added `VerificationStatus` enum for standardizing verification statuses.
- Integrated routes for `compagnyVerification.php` with API endpoints and middleware.
- Updated `JobPolicy` and `CompagnyPolicy` to include verification checks for recruiters.
- Enhanced `DatabaseSeeder` with sample recruiter data.
- Migrated `profiles` and `compagnies` tables to support enhanced functionality.